### PR TITLE
path argument must not be ref or will segfault

### DIFF
--- a/FSEvents.xs
+++ b/FSEvents.xs
@@ -229,7 +229,7 @@ int _check_process(FSEvents *self)
 MODULE = Mac::FSEvents      PACKAGE = Mac::FSEvents
 
 void
-new (char *klass, HV *args)
+_new (char *klass, HV *args)
 PPCODE:
 {
     SV *pv = NEWSV(0, sizeof(FSEvents));
@@ -258,10 +258,6 @@ PPCODE:
         self->flags = (FSEventStreamCreateFlags)SvIV(*svp);
     }
 
-    if ( !self->path ) {
-        croak( "Error: path argument to new() must be supplied" );
-    }
-    
     XPUSHs( sv_2mortal( sv_bless(
         newRV_noinc(pv),
         gv_stashpv(klass, 1)

--- a/lib/Mac/FSEvents.pm
+++ b/lib/Mac/FSEvents.pm
@@ -39,6 +39,16 @@ foreach my $constant ( @maybe_export_ok ) {
     }
 }
 
+sub new {
+    my $self = shift;
+    my $args = shift;
+
+    die "path argument to new() must be supplied" unless $args->{path};
+    die "path argument to new() must be plain string" if ref $args->{path};
+
+    return __PACKAGE__->_new( $args );
+}
+
 sub DESTROY {
     my $self = shift;
     

--- a/t/11constructor.t
+++ b/t/11constructor.t
@@ -1,0 +1,34 @@
+#!/usr/bin/perl
+
+use strict;
+
+use Mac::FSEvents;
+
+use Test::More tests => 4;
+
+# Path must be given
+{
+    eval {
+        my $ev = Mac::FSEvents->new({});
+    };
+    ok $@, 'path must be given';
+    like $@, qr{\Qpath argument to new() must be supplied};
+}
+
+# Path must be absolute
+{
+    {
+        package
+            stringified;
+        use overload "" => sub { return $_[0]->{path} };
+    }
+
+    eval {
+        my $ev = Mac::FSEvents->new({
+            path => bless( { path => 'tmp' }, 'stringified' ),
+        });
+    };
+    ok $@, 'path must be string';
+    like $@, qr{\Qpath argument to new() must be plain string};
+}
+


### PR DESCRIPTION
If you give a reference argument to the constructor, the program will
segfault at FSEventStreamCreate().

Since I think it's better to use XS as little as possible, I wrote the
check in the Perl code and moved the underlying XS constructor to a
private method.

An alternative could be to force stringification of the argument, but
that's up for discussion. This at least prevents very terrible things
from happening.
