### PR TITLE
Constructor options

### DIFF
--- a/lib/Mac/FSEvents.pm
+++ b/lib/Mac/FSEvents.pm
@@ -41,7 +41,14 @@ foreach my $constant ( @maybe_export_ok ) {
 
 sub new {
     my $self = shift;
-    my $args = shift;
+
+    my $args;
+    if ( @_ == 1 ) {
+        $args = shift;
+    }
+    else {
+        $args = { @_ };
+    }
 
     die "path argument to new() must be supplied" unless $args->{path};
     die "path argument to new() must be plain string" if ref $args->{path};

--- a/t/05event.t
+++ b/t/05event.t
@@ -107,11 +107,12 @@ my $since;
 
 # Test since param and that we receive a history_done flag
 {
-	my $fs = Mac::FSEvents->new( {
+    # Test name/value pairs as constructor
+	my $fs = Mac::FSEvents->new(
 		path    => $tmpdir,
 		since   => $since,
 		latency => 0.5,
-	} );
+	);
 	
 	$fs->watch;
 	


### PR DESCRIPTION
This is based on the previous pull request (#2) and allows the user to specify either a hashref or a simple list of name => value pairs to the constructor.

If you think it's a good idea, I could also add an option for specifying only the path as a simple string. It looks like the underlying FSEventsStreamCreate accepts an array of paths to watch, so that might be an option I can look into as well...
